### PR TITLE
Consolidate documentation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,12 +34,62 @@ jobs:
         run: |
           pip install furo sphinx==3.0.3 sphinx-argparse sphinx-copybutton sphinx-multibuild sphinxcontrib-spelling
 
-      # Checkout other mc2 projects
       - name: Checkout mc2 client
         uses: actions/checkout@v2
         with:
             repository: mc2-project/mc2
             path: mc2
+
+      - name: Install mc2 client apt package dependencies
+        run: |
+          # Install OpenEnclave 0.12.0
+          echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu bionic main' | sudo tee /etc/apt/sources.list.d/intel-sgx.list
+          wget -qO - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | sudo apt-key add -
+          echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-7 main" | sudo tee /etc/apt/sources.list.d/llvm-toolchain-bionic-7.list
+          wget -qO - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+          echo "deb [arch=amd64] https://packages.microsoft.com/ubuntu/18.04/prod bionic main" | sudo tee /etc/apt/sources.list.d/msprod.list
+          wget -qO - https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
+
+          sudo apt update
+          sudo apt -y install clang-7 libssl-dev gdb libsgx-enclave-common libsgx-enclave-common-dev libprotobuf10 libsgx-dcap-ql libsgx-dcap-ql-dev az-dcap-client open-enclave=0.12.0 enchant
+
+          # CMake
+          wget https://github.com/Kitware/CMake/releases/download/v3.15.6/cmake-3.15.6-Linux-x86_64.sh
+
+          # Mbed TLS
+          sudo apt-get install -y libmbedtls-dev
+
+      - name: Build mc2 client C++
+        run: | 
+          # Build C++ source
+          cd mc2
+          cd src
+          mkdir build
+          cd build
+          cmake ..
+          make -j4
+          cd ../..
+
+      - name: Install Python dependencies
+        run: |
+          cd mc2
+          pip install -r requirements.txt 
+
+      - name: Install mc2client Python package
+        run: |
+          # Install the Python package
+          cd mc2/python-package
+          python setup.py install
+
+      - name: Checkout sequencefile Python package
+        uses: actions/checkout@master
+        with:
+            path: sequencefile
+            repository: opaque-systems/sequencefile
+
+      - name: Install sequencefile Python package
+        run: cd sequencefile; python setup.py install
+        shell: bash
 
       - name: Checkout Opaque SQL
         uses: actions/checkout@v2
@@ -49,7 +99,8 @@ jobs:
 
       - name: Build docs
         run: |
-          sphinx-multibuild -i main -i mc2/ -i opaque-sql -s main/_build/tmp -o main/_build/html -b html
+          cd main
+          sphinx-multibuild -i . -i ../mc2/ -i ../opaque-sql -s _build/tmp -o _build/html -b html
 
       - name: Clone gh-pages branch
         uses: actions/checkout@v2

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,10 @@ on:
     branches:    
       - master
 
+  pull_request:
+      branches:
+      - master
+
 jobs:
   build:
     runs-on: ubuntu-18.04
@@ -24,11 +28,24 @@ jobs:
    
       - name: Install dependencies
         run: |
-          pip install furo sphinx==3.0.3 sphinx-argparse sphinx-copybutton sphinxcontrib-spelling
+          pip install furo sphinx==3.0.3 sphinx-argparse sphinx-copybutton sphinx-multibuild sphinxcontrib-spelling
+
+      # Checkout other mc2 projects
+      - name: Checkout mc2 client
+        uses: actions/checkout@v2
+        with:
+            repository: mc2-project/mc2
+            path: ../mc2
+
+      - name: Checkout Opaque SQL
+        uses: actions/checkout@v2
+        with:
+            repository: mc2-project/opaque-sql
+            path: ../opaque-sql
 
       - name: Build docs
         run: |
-          make html
+          sphinx-multibuild -i . -i ../mc2/ -i ../opaque-sql -s ./_build/tmp -o ./_build/html -b html
 
       - name: Clone gh-pages branch
         uses: actions/checkout@v2

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: true
+          path: main
 
       - name: Set up Python 3.6
         uses: actions/setup-python@v2
@@ -35,17 +36,17 @@ jobs:
         uses: actions/checkout@v2
         with:
             repository: mc2-project/mc2
-            path: ../mc2
+            path: mc2
 
       - name: Checkout Opaque SQL
         uses: actions/checkout@v2
         with:
             repository: mc2-project/opaque-sql
-            path: ../opaque-sql
+            path: opaque-sql
 
       - name: Build docs
         run: |
-          sphinx-multibuild -i . -i ../mc2/ -i ../opaque-sql -s ./_build/tmp -o ./_build/html -b html
+          sphinx-multibuild -i main -i mc2/ -i opaque-sql -s main/_build/tmp -o main/_build/html -b html
 
       - name: Clone gh-pages branch
         uses: actions/checkout@v2
@@ -56,7 +57,7 @@ jobs:
 
       - name: Commit documentation changes
         run: |
-          cp -r _build/html/* gh-pages/
+          cp -r main/_build/html/* gh-pages/
           cd gh-pages
           touch .nojekyll
           git config --local user.email "action@github.com"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,6 +9,9 @@ on:
       branches:
       - master
 
+  repository_dispatch:
+    types: [client-docs-dispatch]
+
 jobs:
   build:
     runs-on: ubuntu-18.04

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,12 +36,62 @@ jobs:
         run: |
           pip install furo sphinx==3.0.3 sphinx-argparse sphinx-copybutton sphinx-multibuild sphinxcontrib-spelling
 
-      # Checkout other mc2 projects
       - name: Checkout mc2 client
         uses: actions/checkout@v2
         with:
             repository: mc2-project/mc2
             path: mc2
+
+      - name: Install mc2 client apt package dependencies
+        run: |
+          # Install OpenEnclave 0.12.0
+          echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu bionic main' | sudo tee /etc/apt/sources.list.d/intel-sgx.list
+          wget -qO - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | sudo apt-key add -
+          echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-7 main" | sudo tee /etc/apt/sources.list.d/llvm-toolchain-bionic-7.list
+          wget -qO - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+          echo "deb [arch=amd64] https://packages.microsoft.com/ubuntu/18.04/prod bionic main" | sudo tee /etc/apt/sources.list.d/msprod.list
+          wget -qO - https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
+
+          sudo apt update
+          sudo apt -y install clang-7 libssl-dev gdb libsgx-enclave-common libsgx-enclave-common-dev libprotobuf10 libsgx-dcap-ql libsgx-dcap-ql-dev az-dcap-client open-enclave=0.12.0 enchant
+
+          # CMake
+          wget https://github.com/Kitware/CMake/releases/download/v3.15.6/cmake-3.15.6-Linux-x86_64.sh
+
+          # Mbed TLS
+          sudo apt-get install -y libmbedtls-dev
+
+      - name: Build mc2 client C++
+        run: | 
+          # Build C++ source
+          cd mc2
+          cd src
+          mkdir build
+          cd build
+          cmake ..
+          make -j4
+          cd ../..
+
+      - name: Install Python dependencies
+        run: |
+          cd mc2
+          pip install -r requirements.txt 
+
+      - name: Install mc2client Python package
+        run: |
+          # Install the Python package
+          cd mc2/python-package
+          python setup.py install
+
+      - name: Checkout sequencefile Python package
+        uses: actions/checkout@master
+        with:
+            path: sequencefile
+            repository: opaque-systems/sequencefile
+
+      - name: Install sequencefile Python package
+        run: cd sequencefile; python setup.py install
+        shell: bash
 
       - name: Checkout Opaque SQL
         uses: actions/checkout@v2
@@ -51,5 +101,6 @@ jobs:
 
       - name: Build docs
         run: |
-          sphinx-multibuild -i main -i mc2/ -i opaque-sql -s main/_build/tmp -o main/_build/html -b html
+          cd main
+          sphinx-multibuild -i . -i ../mc2/ -i ../opaque-sql -s _build/tmp -o _build/html -b html
    

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: true
+          path: main
 
       - name: Set up Python 3.6
         uses: actions/setup-python@v2
@@ -30,15 +31,25 @@ jobs:
 
       - name: Upgrade Pip
         run: python -m pip install --upgrade pip setuptools wheel
-   
+
       - name: Install dependencies
         run: |
-          pip install furo sphinx==3.0.3 sphinx-argparse sphinx-copybutton sphinxcontrib-spelling
+          pip install furo sphinx==3.0.3 sphinx-argparse sphinx-copybutton sphinx-multibuild sphinxcontrib-spelling
+
+      # Checkout other mc2 projects
+      - name: Checkout mc2 client
+        uses: actions/checkout@v2
+        with:
+            repository: mc2-project/mc2
+            path: mc2
+
+      - name: Checkout Opaque SQL
+        uses: actions/checkout@v2
+        with:
+            repository: mc2-project/opaque-sql
+            path: opaque-sql
 
       - name: Build docs
         run: |
-          make html
-
-      # - name: Run spellcheck
-      #   run : |
-      #       sphinx-build -b spelling . _build
+          sphinx-multibuild -i main -i mc2/ -i opaque-sql -s main/_build/tmp -o main/_build/html -b html
+   

--- a/conf.py
+++ b/conf.py
@@ -41,7 +41,6 @@ extensions = [
     "sphinxarg.ext",
     "sphinx_copybutton",
     "sphinxcontrib.spelling",
-    "sphinx.ext.intersphinx",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -89,7 +88,3 @@ spelling_word_list_filename = "spelling_wordlist.txt"
 
 # Emit misspelling as Sphinx warning
 spelling_warning = True
-
-intersphinx_mapping = {
-    "client": ("https://mc2-project.github.io/mc2/", None),
-}

--- a/conf.py
+++ b/conf.py
@@ -41,6 +41,7 @@ extensions = [
     "sphinxarg.ext",
     "sphinx_copybutton",
     "sphinxcontrib.spelling",
+    "sphinx.ext.intersphinx",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -88,3 +89,7 @@ spelling_word_list_filename = "spelling_wordlist.txt"
 
 # Emit misspelling as Sphinx warning
 spelling_warning = True
+
+intersphinx_mapping = {
+    "client": ("https://mc2-project.github.io/mc2/", None),
+}

--- a/documentation.rst
+++ b/documentation.rst
@@ -8,8 +8,8 @@ You can find links to the documentation to each component of MC\ :sup:`2` below.
 .. toctree::
     :maxdepth: 2
 
-    MC2 Client <https://mc2-project.github.io/mc2/>
-    Opaque SQL <https://mc2-project.github.io/opaque-sql/>
+    MC2 Client <client-docs/index>
+    Opaque SQL <opaque-sql-docs/src/index>
     Secure XGBoost <https://mc2-project.github.io/secure-xgboost/>
     Federated XGBoost <https://github.com/mc2-project/federated-xgboost>
 

--- a/documentation.rst
+++ b/documentation.rst
@@ -10,6 +10,4 @@ You can find links to the documentation to each component of MC\ :sup:`2` below.
 
     MC2 Client <client-docs/index>
     Opaque SQL <opaque-sql-docs/src/index>
-    Secure XGBoost <https://mc2-project.github.io/secure-xgboost/>
-    Federated XGBoost <https://github.com/mc2-project/federated-xgboost>
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ setuptools
 sphinx==3.0.3
 sphinx-argparse
 sphinx-copybutton
+sphinx-multibuild
 sphinxcontrib-spelling


### PR DESCRIPTION
This PR consolidates all documentation across the mc2-project into one site: mc2-project.github.io. Previously, documentation for each project had its own individual site, e.g. mc2-project.github.io/mc2, mc2-project.github.io/opaque-sql. With this change, all documentation will be hosted on the same site.

TODOs:
* [x] change client docs to be in `client-docs` directory
* [x] change the `filename` value of argparse of client [CLI](https://github.com/mc2-project/mc2/blob/master/client-docs/cli/api.rst) to point to the correct path. Doing this will mean that the client documentation CLI API will break.
* [x] change Opaque SQL docs to be in `opaque-sql-docs` directory
* [x] modify GitHub actions workflow to checkout the client + Opaque SQL directories, and to use `sphinx-multibuild` to build documentation together
* [x] modify each of client + Opaque SQL repo GitHub actions to [trigger](https://github.community/t/trigger-a-workflow-from-another-workflow/17395) this repo's documentation workflow upon a push to master